### PR TITLE
isl_ast_node_dup: fix handling of degenerate for loops

### DIFF
--- a/isl_ast.c
+++ b/isl_ast.c
@@ -1018,6 +1018,11 @@ __isl_give isl_ast_node *isl_ast_node_copy(__isl_keep isl_ast_node *node)
 	return node;
 }
 
+/* Return a fresh copy of "node".
+ *
+ * In the case of a degenerate for node, take into account
+ * that "cond" and "inc" are NULL.
+ */
 __isl_give isl_ast_node *isl_ast_node_dup(__isl_keep isl_ast_node *node)
 {
 	isl_ast_node *dup;
@@ -1039,13 +1044,17 @@ __isl_give isl_ast_node *isl_ast_node_dup(__isl_keep isl_ast_node *node)
 			return isl_ast_node_free(dup);
 		break;
 	case isl_ast_node_for:
+		dup->u.f.degenerate = node->u.f.degenerate;
 		dup->u.f.iterator = isl_ast_expr_copy(node->u.f.iterator);
 		dup->u.f.init = isl_ast_expr_copy(node->u.f.init);
+		dup->u.f.body = isl_ast_node_copy(node->u.f.body);
+		if (!dup->u.f.iterator || !dup->u.f.init || !dup->u.f.body)
+			return isl_ast_node_free(dup);
+		if (node->u.f.degenerate)
+			break;
 		dup->u.f.cond = isl_ast_expr_copy(node->u.f.cond);
 		dup->u.f.inc = isl_ast_expr_copy(node->u.f.inc);
-		dup->u.f.body = isl_ast_node_copy(node->u.f.body);
-		if (!dup->u.f.iterator || !dup->u.f.init || !dup->u.f.cond ||
-		    !dup->u.f.inc || !dup->u.f.body)
+		if (!dup->u.f.cond || !dup->u.f.inc)
 			return isl_ast_node_free(dup);
 		break;
 	case isl_ast_node_block:


### PR DESCRIPTION
Ever since the introduction of AST generation support
in isl-0.10-199-g5888ac1c9f (add support for generating ASTs
from schedule relations, Mon Sep 17 22:11:06 2012 +0200),
the cond and inc fields have been documented as being NULL
in the case of degenerate for loops.
However this was not being taken into account by isl_ast_node_dup.
In fact, it did not even preserve the flag indicating the property.

Preserve the property and do not copy these fields
in the case of a degenerate for loop.  In particular,
NULL values in the copy should definitely not be considered an error.
Note that all fields are initialized to zero in isl_ast_node_alloc,
so these fields do not need to be explicitly initialized to NULL
once more.

Signed-off-by: Sven Verdoolaege <sven@cerebras.net>